### PR TITLE
Psmove tracker

### DIFF
--- a/core/components/CMakeLists.txt
+++ b/core/components/CMakeLists.txt
@@ -21,6 +21,15 @@ set (REQUIRED_CISST_LIBRARIES cisstCommon
 
 find_package (cisst 1.2.0 COMPONENTS ${REQUIRED_CISST_LIBRARIES})
 
+# # Optional OpenCV (needed by psmoveapi_tracker)
+find_package(OpenCV QUIET)
+
+if(OpenCV_FOUND)
+  # OpenCV found - tracking support enabled
+else()
+  message("Building without OpenCV support. PSMove tracking will be disabled.")
+endif()
+
 if (cisst_FOUND_AS_REQUIRED)
 
   # load cisst configuration
@@ -58,6 +67,9 @@ if (cisst_FOUND_AS_REQUIRED)
                          FOLDER "sawPSMove")
 
   target_link_libraries (sawPSMove psmoveapi)
+  if(OpenCV_FOUND)
+    target_link_libraries(sawPSMove psmoveapi_tracker ${OpenCV_LIBRARIES})
+  endif()
 
   cisst_target_link_libraries (sawPSMove ${REQUIRED_CISST_LIBRARIES})
 

--- a/core/components/code/mtsPSMove.cpp
+++ b/core/components/code/mtsPSMove.cpp
@@ -38,18 +38,6 @@ CMN_IMPLEMENT_SERVICES_DERIVED_ONEARG(mtsPSMove,
                                       mtsTaskPeriodic,
                                       mtsTaskPeriodicConstructorArg);
 
-static const char* cam_status_str(mtsPSMove::CameraStatus s) {
-    switch (s) {
-        case mtsPSMove::CameraStatus::Disabled:    return "Disabled";
-        case mtsPSMove::CameraStatus::Starting:    return "Starting";
-        case mtsPSMove::CameraStatus::Calibrating: return "Calibrating";
-        case mtsPSMove::CameraStatus::Ready:       return "Ready";
-        case mtsPSMove::CameraStatus::Error:       return "Error";
-    }
-    return "Unknown";
-}
-
-
 mtsPSMove::mtsPSMove(const std::string & component_name, const double & period_in_seconds):
     mtsTaskPeriodic(component_name, period_in_seconds)
 {
@@ -491,7 +479,11 @@ void mtsPSMove::camera_set_status_(CameraStatus s, const char *info)
     if (m_camera_status == s) return;
     m_camera_status = s;
 
-    m_camera_status_str = cam_status_str(s);
+    static constexpr const char* status_names[] = {
+        "Disabled", "Starting", "Calibrating", "Ready", "Error"
+    };
+    const auto index = static_cast<size_t>(s);
+    m_camera_status_str = (index < sizeof(status_names)/sizeof(status_names[0])) ? status_names[index] : "Unknown";
     if (info) m_camera_status_str += std::string(" (") + info + ")";
 
     switch (s) {

--- a/core/components/include/sawPSMove/mtsPSMove.h
+++ b/core/components/include/sawPSMove/mtsPSMove.h
@@ -34,6 +34,9 @@ http://www.cisst.org/cisst/license.txt.
 struct _PSMove;
 typedef struct _PSMove PSMove;
 
+struct _PSMoveTracker;
+typedef struct _PSMoveTracker PSMoveTracker;
+
 class CISST_EXPORT mtsPSMove: public mtsTaskPeriodic
 {
     CMN_DECLARE_SERVICES(CMN_DYNAMIC_CREATION_ONEARG, CMN_LOG_ALLOW_DEFAULT);
@@ -70,10 +73,31 @@ protected:
     void update_data(void);
     void state_command(const std::string & command);
 
+    // Camera commands
+    void enable_camera(const bool &enable); // This enables the camera. Might need a better name.
+    void calibrate_camera(void); // Try to calibrate/enable tracking; might need a better name.
+    void set_intrinsics(const vctDouble4 &fx_fy_cx_cy);
+    void set_sphere_radius(const double &radius_m);
+    void set_camera_translation(const vctDouble3 &translation);
+    void set_camera_rotation(const vctMatRot3 &rotation);
+
     // PSMove handle
     PSMove * m_move_handle = nullptr;
+    // Tracker handle (optional)
+    PSMoveTracker * m_tracker_handle = nullptr;
+
     int m_controller_index = 0;
     bool m_orientation_available = false;
+
+    // Camera pipeline configuration
+    bool   m_camera_enabled = true; // FIXME: default to true for now. 
+    bool   m_camera_calibrated = false;
+    double m_fx = 800.0, m_fy = 800.0, m_cx = 320.0, m_cy = 240.0;  // pixels
+    double m_sphere_radius_m = 0.0225;                               // ~22.5 mm ball
+
+    // Camera to world transform
+    vctMatRot3 m_R_world_cam;  // 3x3 rotation
+    vctDouble3 m_t_world_cam;  // world ⟵ cam
 
     // State
     prmOperatingState m_operating_state;

--- a/core/components/include/sawPSMove/mtsPSMove.h
+++ b/core/components/include/sawPSMove/mtsPSMove.h
@@ -104,7 +104,7 @@ protected:
     bool m_orientation_available = false;
 
     // Camera config
-    bool m_camera_requested = true;                // user's desired state
+    bool m_camera_requested = false;                // user's desired state
     CameraStatus m_camera_status = CameraStatus::Disabled;
     bool m_camera_have_pose = false;
     double m_fx = 800.0, m_fy = 800.0, m_cx = 320.0, m_cy = 240.0; // intrinsics


### PR DESCRIPTION
Position tracking working. Handling camera state. Enable/disable via the move button. Camera calibration can take a few seconds.

Known Issue: Trying to enable camera tracking when a PS Tracker is not connected.